### PR TITLE
harness: fixed 'Unexpected critical/warning: [...] Got data flow before ...

### DIFF
--- a/libs/gst/check/gstharness.c
+++ b/libs/gst/check/gstharness.c
@@ -489,8 +489,14 @@ gst_harness_new_full (GstElement * element,
   if (h->srcpad != NULL) {
     gchar * stream_id = g_strdup_printf ("%s-%p",
         GST_OBJECT_NAME (h->element), h);
+
+    GstSegment segment;
+    gst_segment_init(&segment, GST_FORMAT_TIME);
+
     g_assert (gst_pad_push_event (h->srcpad,
           gst_event_new_stream_start (stream_id)));
+    g_assert (gst_pad_push_event (h->srcpad,
+          gst_event_new_segment (&segment)));
     g_free (stream_id);
   }
 


### PR DESCRIPTION
...segment event' error

When try to run the first example you presented on the GStreamer Conference 2013 I get the above mentioned error. The patch should fix it.
