### PR TITLE
rtprtxsend: refactoring stuffing logic

### DIFF
--- a/subprojects/gst-plugins-good/gst/rtpmanager/gstrtprtxsend.h
+++ b/subprojects/gst-plugins-good/gst/rtpmanager/gstrtprtxsend.h
@@ -87,8 +87,9 @@ struct _GstRtpRtxSend
   /* stuffing properties */
   gint stuffing_kbps;
   gint stuffing_max_burst;
-  /* stuffing token bucket */
-  gint stuffing_max_packet_size;
+
+  /* last ssrc used for stuffing */
+  gint last_stuffing_ssrc;
 
   TokenBucket stuff_tb;
 };


### PR DESCRIPTION
Introducing stuffing for packets that are not marked with RTX.  This was
added since we don't want to depend on packets for RTX to trigger the stuffing.

With this change, if a packet comes and is not marked for RTX, the
stuffing will be done with the last RTX packet sent.

Removed the padding for stuffing, as it is removed later on the
pipeline.

Fixed other minor bugs around the tocken bucket manipulation.

Co-authored-by: Håvard Graff <hgr@pexip.com>