### PR TITLE
TWCC manager relies on buffers meta for recovery percentage 

### DIFF
--- a/subprojects/gst-plugins-base/gst-libs/gst/rtp/gstrtprepairmeta.c
+++ b/subprojects/gst-plugins-base/gst-libs/gst/rtp/gstrtprepairmeta.c
@@ -1,0 +1,134 @@
+/* GStreamer
+ * Copyright (C) <2024> Mikhail Baranov <mikhail.baranov@pexip.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#include "gstrtprepairmeta.h"
+#include <string.h>
+
+static gboolean gst_rtp_repair_meta_init(GstRTPRepairMeta * meta, 
+    G_GNUC_UNUSED gpointer params, G_GNUC_UNUSED GstBuffer * buffer);
+static void gst_rtp_repair_meta_free(GstRTPRepairMeta *meta,
+    G_GNUC_UNUSED GstBuffer *buffer);
+
+
+GType gst_rtp_repair_meta_api_get_type(void)
+{
+  static GType type = 0;
+  static const gchar *tags[] = {NULL};
+
+  if (g_once_init_enter(&type)) {
+    GType _type = gst_meta_api_type_register("GstRTPRepairMetaAPI", tags);
+    g_once_init_leave(&type, _type);
+  }
+
+  return type;
+}
+
+const GstMetaInfo *gst_rtp_repair_meta_get_info(void)
+{
+  static const GstMetaInfo *meta_info = NULL;
+
+  if (g_once_init_enter(&meta_info)) {
+    const GstMetaInfo *mi = gst_meta_register( GST_RTP_REPAIR_META_API_TYPE,
+        "GstRTPRepairMeta",
+        sizeof(GstRTPRepairMeta),
+        (GstMetaInitFunction) gst_rtp_repair_meta_init,
+        (GstMetaFreeFunction) gst_rtp_repair_meta_free,
+        NULL );
+    g_once_init_leave(&meta_info, mi);
+  }
+
+  return meta_info;
+}
+
+GstRTPRepairMeta *gst_buffer_get_rtp_repair_meta(GstBuffer *buffer)
+{
+  return (GstRTPRepairMeta *)gst_buffer_get_meta(buffer,
+    gst_rtp_repair_meta_api_get_type());
+}
+
+GstRTPRepairMeta *gst_buffer_add_rtp_repair_meta(GstBuffer *buffer,
+  const guint32 ssrc, const guint16 *seqnum, guint seqnum_count)
+{
+  GstRTPRepairMeta *repair_meta = (GstRTPRepairMeta *) gst_buffer_add_meta (buffer,
+      GST_RTP_REPAIR_META_INFO, NULL);
+  if (repair_meta == NULL) {
+    return NULL;
+  }
+
+  repair_meta->ssrc = ssrc;
+  g_array_set_size(repair_meta->seqnums, seqnum_count);
+  memcpy(repair_meta->seqnums->data, seqnum, seqnum_count * sizeof(guint16));
+
+  return repair_meta;
+}
+
+gboolean gst_buffer_repairs_seqnum(GstBuffer *buffer, guint16 seqnum, guint32 ssrc)
+{
+  GstRTPRepairMeta *repair_meta = gst_buffer_get_rtp_repair_meta(buffer);
+  if (repair_meta) {
+    if (repair_meta->ssrc != ssrc) {
+      return FALSE;
+    }
+
+    for (guint i = 0; i < repair_meta->seqnums->len; i++) {
+      guint16 stored_seqnum = g_array_index(repair_meta->seqnums, guint16, i);
+      if (stored_seqnum == seqnum) {
+        return TRUE;
+      }
+    }
+  }
+  return FALSE;
+}
+
+gboolean gst_buffer_get_repair_seqnums(GstBuffer *buffer, guint32 *ssrc,
+    GArray **seqnums)
+{
+  GstRTPRepairMeta *repair_meta = gst_buffer_get_rtp_repair_meta(buffer);
+  if (repair_meta && repair_meta->seqnums->len > 0) {
+    if (ssrc) {
+      *ssrc = repair_meta->ssrc;
+    }
+    if (seqnums) {
+      *seqnums = g_array_ref (repair_meta->seqnums);
+    }
+    return TRUE;
+  }
+  return FALSE;
+}
+
+static gboolean
+gst_rtp_repair_meta_init(GstRTPRepairMeta * meta, G_GNUC_UNUSED gpointer params, 
+    G_GNUC_UNUSED GstBuffer * buffer)
+{
+  meta->ssrc = 0;
+  meta->seqnums = g_array_new(FALSE, FALSE, sizeof(guint16));
+
+  return TRUE;
+}
+
+static void
+gst_rtp_repair_meta_free(GstRTPRepairMeta *meta,
+    G_GNUC_UNUSED GstBuffer *buffer)
+{
+  g_array_unref (meta->seqnums);
+}

--- a/subprojects/gst-plugins-base/gst-libs/gst/rtp/gstrtprepairmeta.h
+++ b/subprojects/gst-plugins-base/gst-libs/gst/rtp/gstrtprepairmeta.h
@@ -1,0 +1,63 @@
+/* GStreamer
+ * Copyright (C) <2024> Mikhail Baranov <mikhail.baranov@pexip.com>
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Library General Public
+ * License as published by the Free Software Foundation; either
+ * version 2 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Library General Public License for more details.
+ *
+ * You should have received a copy of the GNU Library General Public
+ * License along with this library; if not, write to the
+ * Free Software Foundation, Inc., 51 Franklin St, Fifth Floor,
+ * Boston, MA 02110-1301, USA.
+ */
+
+#ifndef __GST_RTP_REPAIR_META_H__
+#define __GST_RTP_REPAIR_META_H__
+
+#include <gst/gst.h>
+#include <glib.h>
+#include <gst/rtp/rtp-prelude.h>
+
+G_BEGIN_DECLS
+
+#define GST_RTP_REPAIR_META_API_TYPE  (gst_rtp_repair_meta_api_get_type())
+#define GST_RTP_REPAIR_META_INFO  (gst_rtp_repair_meta_get_info())
+typedef struct _GstRTPRepairMeta GstRTPRepairMeta;
+
+struct _GstRTPRepairMeta
+{
+  GstMeta meta;
+
+  guint32 ssrc;
+  GArray *seqnums;
+};
+
+GST_RTP_API
+GType               gst_rtp_repair_meta_api_get_type     (void);
+
+GST_RTP_API
+GstRTPRepairMeta *  gst_buffer_add_rtp_repair_meta       (GstBuffer *buffer, const guint32 ssrc,
+                                                          const guint16 *seqnum, guint seqnum_count);
+
+GST_RTP_API
+GstRTPRepairMeta *  gst_buffer_get_rtp_repair_meta       (GstBuffer * buffer);
+
+GST_RTP_API
+gboolean gst_buffer_repairs_seqnum(GstBuffer *buffer, guint16 seqnum, guint32 ssrc);
+
+GST_RTP_API
+gboolean gst_buffer_get_repair_seqnums(GstBuffer *buffer, guint32 * ssrc,
+    GArray ** seqnums);
+
+GST_RTP_API
+const GstMetaInfo * gst_rtp_repair_meta_get_info         (void);
+
+G_END_DECLS
+
+#endif /* __GST_RTP_REPAIR_META_H__ */

--- a/subprojects/gst-plugins-base/gst-libs/gst/rtp/meson.build
+++ b/subprojects/gst-plugins-base/gst-libs/gst/rtp/meson.build
@@ -4,6 +4,7 @@ rtp_sources = files([
   'gstrtppayloads.c',
   'gstrtphdrext.c',
   'gstrtpmeta.c',
+  'gstrtprepairmeta.c',
   'gstrtpbaseaudiopayload.c',
   'gstrtpbasepayload.c',
   'gstrtpbasedepayload.c'
@@ -18,6 +19,7 @@ rtp_headers = files([
   'gstrtpdefs.h',
   'gstrtphdrext.h',
   'gstrtpmeta.h',
+  'gstrtprepairmeta.h',
   'gstrtppayloads.h',
   'rtp-prelude.h',
   'rtp.h',

--- a/subprojects/gst-plugins-good/gst/rtpmanager/gstrtprtxsend.c
+++ b/subprojects/gst-plugins-good/gst/rtpmanager/gstrtprtxsend.c
@@ -46,6 +46,7 @@
 
 #include "gstrtprtxsend.h"
 #include "rtpstats.h"
+#include <gst/rtp/gstrtprepairmeta.h>
 
 GST_DEBUG_CATEGORY_STATIC (gst_rtp_rtx_send_debug);
 #define GST_CAT_DEFAULT gst_rtp_rtx_send_debug
@@ -765,6 +766,7 @@ gst_rtp_rtx_buffer_new (GstRtpRtxSend * rtx, GstBuffer * buffer, guint8 padlen)
   SSRCRtxData *data;
   guint32 ssrc;
   guint16 seqnum;
+  guint16 orig_seqnum;
   guint8 fmtp;
 
   gst_rtp_buffer_map (buffer, GST_MAP_READ, &rtp);
@@ -776,10 +778,14 @@ gst_rtp_rtx_buffer_new (GstRtpRtxSend * rtx, GstBuffer * buffer, guint8 padlen)
   seqnum = data->next_seqnum++;
   fmtp = GPOINTER_TO_UINT (g_hash_table_lookup (rtx->rtx_pt_map,
           GUINT_TO_POINTER (gst_rtp_buffer_get_payload_type (&rtp))));
+  
+  orig_seqnum = gst_rtp_buffer_get_seq (&rtp);
 
   GST_DEBUG_OBJECT (rtx, "creating rtx buffer, orig seqnum: %u, "
-      "rtx seqnum: %u, rtx ssrc: %X", gst_rtp_buffer_get_seq (&rtp),
+      "rtx seqnum: %u, rtx ssrc: %X", orig_seqnum,
       seqnum, ssrc);
+
+  gst_buffer_add_rtp_repair_meta (new_buffer, ssrc, &orig_seqnum, 1);
 
   /* gst_rtp_buffer_map does not map the payload so do it now */
   gst_rtp_buffer_get_payload (&rtp);


### PR DESCRIPTION
This introduces Buffers Meta API for attaching info of which ssrc and seqnums any particular buffer cares redundant content about.
So far it just substitutes present mechanism for recovery percentage computation for RTX only.