### PR TITLE
use hash for name lookup in gstbin

### DIFF
--- a/subprojects/gstreamer/gst/gstbin.h
+++ b/subprojects/gstreamer/gst/gstbin.h
@@ -325,6 +325,16 @@ void            gst_bin_set_suppressed_flags (GstBin * bin, GstElementFlags flag
 GST_API
 GstElementFlags gst_bin_get_suppressed_flags (GstBin * bin);
 
+/* set and get information about hash usage */
+GST_API
+gboolean        gst_bin_get_using_hash (GstBin * bin);
+
+GST_API
+void            gst_bin_set_hash_level (GstBin * bin, gint value);
+
+GST_API
+gint            gst_bin_get_hash_level (GstBin * bin);
+
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GstBin, gst_object_unref)
 
 G_END_DECLS

--- a/subprojects/gstreamer/gst/gstelement.h
+++ b/subprojects/gstreamer/gst/gstelement.h
@@ -791,7 +791,10 @@ struct _GstElement
   GList                *contexts;
 
   /*< private >*/
-  gpointer _gst_reserved[GST_PADDING-1];
+  GHashTable           *pads_hash;
+  gint32               numpads_use_hash;
+
+  gpointer _gst_reserved[GST_PADDING-3];
 };
 
 /**
@@ -1202,6 +1205,16 @@ GST_API
 GList*                  gst_element_get_pad_template_list      (GstElement *element);
 GST_API
 const gchar *           gst_element_get_metadata               (GstElement * element, const gchar * key);
+
+/* set and get information about hash usage */
+GST_API
+gboolean        gst_element_get_using_hash (GstElement * element);
+
+GST_API
+void            gst_element_set_hash_level (GstElement * element, gint value);
+
+GST_API
+gint            gst_element_get_hash_level (GstElement * element);
 
 G_DEFINE_AUTOPTR_CLEANUP_FUNC(GstElement, gst_object_unref)
 

--- a/subprojects/gstreamer/tests/check/gst/gstbin.c
+++ b/subprojects/gstreamer/tests/check/gst/gstbin.c
@@ -214,6 +214,31 @@ GST_START_TEST (test_interface)
 
 GST_END_TEST;
 
+GST_START_TEST (test_duplicate_element)
+{
+  GstBin *bin;
+  GstElement *filesrc, *filesrc2;
+
+  bin = GST_BIN (gst_bin_new (NULL));
+  fail_unless (bin != NULL, "Could not create bin");
+
+  filesrc = gst_element_factory_make ("filesrc", "commonname");
+  fail_unless (filesrc != NULL, "Could not create filesrc");
+  fail_unless (GST_IS_URI_HANDLER (filesrc), "Filesrc not a URI handler");
+  fail_unless (gst_bin_add (bin, filesrc) == TRUE);
+
+  filesrc2 = gst_element_factory_make ("filesrc", "commonname");
+  fail_unless (filesrc2 != NULL, "Could not create filesrc2");
+  fail_unless (GST_IS_URI_HANDLER (filesrc2), "Filesrc not a URI handler");
+  fail_unless (gst_bin_add (bin, filesrc) == FALSE);
+
+  fail_unless (gst_bin_get_by_name(bin, "commonname") == filesrc);
+
+  gst_object_unref (bin);
+}
+
+GST_END_TEST;
+
 GST_START_TEST (test_iterate_all_by_element_factory_name)
 {
   GstBin *bin, *bin2;
@@ -2050,6 +2075,7 @@ gst_bin_suite (void)
 
   suite_add_tcase (s, tc_chain);
   tcase_add_test (tc_chain, test_interface);
+  tcase_add_test (tc_chain, test_duplicate_element);
   tcase_add_test (tc_chain, test_iterate_all_by_element_factory_name);
   tcase_add_test (tc_chain, test_eos);
   tcase_add_test (tc_chain, test_eos_recheck);

--- a/subprojects/gstreamer/tests/check/gst/gstbin.c
+++ b/subprojects/gstreamer/tests/check/gst/gstbin.c
@@ -250,6 +250,14 @@ GST_START_TEST (test_hash_switchover_never)
   fail_unless (gst_bin_get_by_name(bin, "testname2") == filesrc2);
   fail_unless (gst_bin_get_by_name(bin, "testname3") == filesrc3);
 
+  /* Test a couple of removals */
+  fail_unless(gst_bin_remove(bin, filesrc2), TRUE);
+  fail_unless(gst_bin_remove(bin, filesrc3), TRUE);
+  fail_unless(gst_bin_get_using_hash(bin) == FALSE);
+  fail_unless (gst_bin_get_by_name(bin, "testname1") == filesrc);
+  fail_unless (gst_bin_get_by_name(bin, "testname2") == NULL);
+  fail_unless (gst_bin_get_by_name(bin, "testname3") == NULL);
+
   gst_object_unref (bin);
 }
 
@@ -282,6 +290,12 @@ GST_START_TEST (test_hash_switchover_immediate)
   fail_unless (gst_bin_get_by_name(bin, "testname1") == filesrc);
   fail_unless (gst_bin_get_by_name(bin, "testname2") == filesrc2);
 
+  /* Test a removal */
+  fail_unless(gst_bin_remove(bin, filesrc2), TRUE);
+  fail_unless(gst_bin_get_using_hash(bin) == TRUE);
+  fail_unless (gst_bin_get_by_name(bin, "testname1") == filesrc);
+  fail_unless (gst_bin_get_by_name(bin, "testname2") == NULL);
+
   gst_object_unref (bin);
 }
 
@@ -313,6 +327,12 @@ GST_START_TEST (test_hash_switchover_2)
   fail_unless (gst_bin_get_using_hash(bin) == TRUE);
   fail_unless (gst_bin_get_by_name(bin, "testname1") == filesrc);
   fail_unless (gst_bin_get_by_name(bin, "testname2") == filesrc2);
+
+  /* Test a removal */
+  fail_unless(gst_bin_remove(bin, filesrc2), TRUE);
+  fail_unless(gst_bin_get_using_hash(bin) == TRUE);
+  fail_unless (gst_bin_get_by_name(bin, "testname1") == filesrc);
+  fail_unless (gst_bin_get_by_name(bin, "testname2") == NULL);
 
   gst_object_unref (bin);
 }

--- a/subprojects/gstreamer/tests/check/gst/gstelement.c
+++ b/subprojects/gstreamer/tests/check/gst/gstelement.c
@@ -1119,6 +1119,17 @@ GST_START_TEST (test_hash_switchover_never)
   fail_unless(gst_element_get_static_pad(e, "source4") == p4);
   fail_unless(gst_element_get_static_pad(e, "source5") == p5);
 
+  /* Test a couple of removals */
+  fail_unless(gst_element_remove_pad(e, p3), TRUE);
+  fail_unless(gst_element_remove_pad(e, p5), TRUE);
+  fail_unless(gst_element_get_using_hash(e) == FALSE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == NULL);
+  fail_unless(gst_element_get_static_pad(e, "source4") == p4);
+  fail_unless(gst_element_get_static_pad(e, "source5") == NULL);
+
   gst_object_unref (e);
 }
 GST_END_TEST;
@@ -1182,6 +1193,17 @@ GST_START_TEST (test_hash_switchover_immediate)
   fail_unless(gst_element_get_static_pad(e, "source4") == p4);
   fail_unless(gst_element_get_static_pad(e, "source5") == p5);
 
+  /* Test a couple of removals */
+  fail_unless(gst_element_remove_pad(e, p3), TRUE);
+  fail_unless(gst_element_remove_pad(e, p5), TRUE);
+  fail_unless(gst_element_get_using_hash(e) == TRUE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == NULL);
+  fail_unless(gst_element_get_static_pad(e, "source4") == p4);
+  fail_unless(gst_element_get_static_pad(e, "source5") == NULL);
+
   gst_object_unref (e);
 }
 GST_END_TEST;
@@ -1244,6 +1266,17 @@ GST_START_TEST (test_hash_switchover_3)
   fail_unless(gst_element_get_static_pad(e, "source3") == p3);
   fail_unless(gst_element_get_static_pad(e, "source4") == p4);
   fail_unless(gst_element_get_static_pad(e, "source5") == p5);
+
+  /* Test a couple of removals */
+  fail_unless(gst_element_remove_pad(e, p3), TRUE);
+  fail_unless(gst_element_remove_pad(e, p5), TRUE);
+  fail_unless(gst_element_get_using_hash(e) == TRUE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == NULL);
+  fail_unless(gst_element_get_static_pad(e, "source4") == p4);
+  fail_unless(gst_element_get_static_pad(e, "source5") == NULL);
 
   gst_object_unref (e);
 }

--- a/subprojects/gstreamer/tests/check/gst/gstelement.c
+++ b/subprojects/gstreamer/tests/check/gst/gstelement.c
@@ -1061,6 +1061,193 @@ GST_START_TEST (test_add_srcpad_deadlock)
 
 GST_END_TEST;
 
+GST_START_TEST (test_hash_switchover_never)
+{
+  GstElement *e;
+  GstPad *p1, *p2, *p3, *p4, *p5;
+  GstPad *src;
+
+  /* getting an existing element class is cheating, but easier */
+  e = gst_element_factory_make ("fakesrc", "source");
+
+  /* Note that the fakesrc already has one src pad */
+  src = gst_element_get_static_pad(e, "src");
+
+  /* Set the hash switchover level */
+  gst_element_set_hash_level(e, -1);
+
+  /* We should never switch to a list.  Test this with 5 pads (!) */
+  fail_unless(gst_element_get_using_hash(e) == FALSE);
+
+  p1 = gst_pad_new ("source1", GST_PAD_SRC);
+  gst_element_add_pad (e, p1);
+  fail_unless(gst_element_get_using_hash(e) == FALSE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+
+  p2 = gst_pad_new ("source2", GST_PAD_SRC);
+  gst_element_add_pad (e, p2);
+  fail_unless(gst_element_get_using_hash(e) == FALSE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+
+  p3 = gst_pad_new ("source3", GST_PAD_SRC);
+  gst_element_add_pad (e, p3);
+  fail_unless(gst_element_get_using_hash(e) == FALSE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == p3);
+
+  p4 = gst_pad_new ("source4", GST_PAD_SRC);
+  gst_element_add_pad (e, p4);
+  fail_unless(gst_element_get_using_hash(e) == FALSE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == p3);
+  fail_unless(gst_element_get_static_pad(e, "source4") == p4);
+
+  p5 = gst_pad_new ("source5", GST_PAD_SRC);
+  gst_element_add_pad (e, p5);
+  fail_unless(gst_element_get_using_hash(e) == FALSE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == p3);
+  fail_unless(gst_element_get_static_pad(e, "source4") == p4);
+  fail_unless(gst_element_get_static_pad(e, "source5") == p5);
+
+  gst_object_unref (e);
+}
+GST_END_TEST;
+
+
+GST_START_TEST (test_hash_switchover_immediate)
+{
+  GstElement *e;
+  GstPad *p1, *p2, *p3, *p4, *p5;
+  GstPad *src;
+
+  /* getting an existing element class is cheating, but easier */
+  e = gst_element_factory_make ("fakesrc", "source");
+
+  /* Note that the fakesrc already has one src pad */
+  src = gst_element_get_static_pad(e, "src");
+
+  /* Set the hash switchover level */
+  gst_element_set_hash_level(e, 0);
+
+  /* We should immediately move to using a hash as soon as we add one pad */
+  fail_unless(gst_element_get_using_hash(e) == FALSE);
+
+  p1 = gst_pad_new ("source1", GST_PAD_SRC);
+  gst_element_add_pad (e, p1);
+  fail_unless(gst_element_get_using_hash(e) == TRUE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+
+  p2 = gst_pad_new ("source2", GST_PAD_SRC);
+  gst_element_add_pad (e, p2);
+  fail_unless(gst_element_get_using_hash(e) == TRUE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+
+  p3 = gst_pad_new ("source3", GST_PAD_SRC);
+  gst_element_add_pad (e, p3);
+  fail_unless(gst_element_get_using_hash(e) == TRUE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == p3);
+
+  p4 = gst_pad_new ("source4", GST_PAD_SRC);
+  gst_element_add_pad (e, p4);
+  fail_unless(gst_element_get_using_hash(e) == TRUE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == p3);
+  fail_unless(gst_element_get_static_pad(e, "source4") == p4);
+
+  p5 = gst_pad_new ("source5", GST_PAD_SRC);
+  gst_element_add_pad (e, p5);
+  fail_unless(gst_element_get_using_hash(e) == TRUE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == p3);
+  fail_unless(gst_element_get_static_pad(e, "source4") == p4);
+  fail_unless(gst_element_get_static_pad(e, "source5") == p5);
+
+  gst_object_unref (e);
+}
+GST_END_TEST;
+
+GST_START_TEST (test_hash_switchover_3)
+{
+  GstElement *e;
+  GstPad *p1, *p2, *p3, *p4, *p5;
+  GstPad *src;
+
+  /* getting an existing element class is cheating, but easier */
+  e = gst_element_factory_make ("fakesrc", "source");
+
+  /* Note that the fakesrc already has one src pad */
+  src = gst_element_get_static_pad(e, "src");
+
+  /* Set the hash switchover level */
+  gst_element_set_hash_level(e, 3);
+
+  /* We should immediately move to using a hash as soon as we add one pad */
+  fail_unless(gst_element_get_using_hash(e) == FALSE);
+
+  p1 = gst_pad_new ("source1", GST_PAD_SRC);
+  gst_element_add_pad (e, p1);
+  fail_unless(gst_element_get_using_hash(e) == FALSE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+
+  /* We will switch here as this is our third pad */
+  p2 = gst_pad_new ("source2", GST_PAD_SRC);
+  gst_element_add_pad (e, p2);
+  fail_unless(gst_element_get_using_hash(e) == TRUE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+
+  p3 = gst_pad_new ("source3", GST_PAD_SRC);
+  gst_element_add_pad (e, p3);
+  fail_unless(gst_element_get_using_hash(e) == TRUE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == p3);
+
+  p4 = gst_pad_new ("source4", GST_PAD_SRC);
+  gst_element_add_pad (e, p4);
+  fail_unless(gst_element_get_using_hash(e) == TRUE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == p3);
+  fail_unless(gst_element_get_static_pad(e, "source4") == p4);
+
+  p5 = gst_pad_new ("source5", GST_PAD_SRC);
+  gst_element_add_pad (e, p5);
+  fail_unless(gst_element_get_using_hash(e) == TRUE);
+  fail_unless(gst_element_get_static_pad(e, "src") == src);
+  fail_unless(gst_element_get_static_pad(e, "source1") == p1);
+  fail_unless(gst_element_get_static_pad(e, "source2") == p2);
+  fail_unless(gst_element_get_static_pad(e, "source3") == p3);
+  fail_unless(gst_element_get_static_pad(e, "source4") == p4);
+  fail_unless(gst_element_get_static_pad(e, "source5") == p5);
+
+  gst_object_unref (e);
+}
+GST_END_TEST;
 
 static Suite *
 gst_element_suite (void)
@@ -1082,6 +1269,9 @@ gst_element_suite (void)
   tcase_add_test (tc_chain, test_foreach_pad);
   tcase_add_test (tc_chain, test_release_pads_during_dispose);
   tcase_add_test (tc_chain, test_add_srcpad_deadlock);
+  tcase_add_test (tc_chain, test_hash_switchover_never);
+  tcase_add_test (tc_chain, test_hash_switchover_immediate);
+  tcase_add_test (tc_chain, test_hash_switchover_3);
 
   return s;
 }


### PR DESCRIPTION
This patch adds the ability to use a hash when adding/updating/removing elements from a gstbin.

A rough performance test shows the following behaviour (this is with the switchover point set to 0 elements)

![image](https://github.com/user-attachments/assets/cb33bd8b-ac09-4f5b-9392-67357bc5700e)

(Note that this is a single run and could do with being re-run a number of times and averages / variances calculated)

If the switchover point is set to -1, we will never use the hash.  If it is 0, we will always use the hash.  If it is > 0, we will start using the hash when we hit that number of elements.  This may be over-complicated and one option is to go back to just the first patch in this series which just always uses the hash.

This does *not* solve the same problem which occurs with pads in the gstelement code.  If someone can point me at how to use some of the reserved padding space at the end of the gstelement structure to safely add a private struct pointer in this space without breaking the ABI on any platform, I'll do the same there as well if we think it's necessary.