### PR TITLE
gstelement: improve locking around hash usage

### DIFF
--- a/subprojects/gstreamer/gst/gstbin.c
+++ b/subprojects/gstreamer/gst/gstbin.c
@@ -540,19 +540,23 @@ gst_bin_dispose (GObject * object)
   while (bin->children) {
     element = GST_ELEMENT_CAST (bin->children->data);
     if (bin->priv->children_hash != NULL) {
+      GST_OBJECT_LOCK (object);
       g_hash_table_remove (bin->priv->children_hash, GST_ELEMENT_NAME (element));
+      GST_OBJECT_UNLOCK (object);
     }
     gst_bin_remove (bin, element);
+  }
+
+  if (bin->priv->children_hash != NULL) {
+    GST_OBJECT_LOCK (object);
+    g_hash_table_destroy (bin->priv->children_hash);
+    GST_OBJECT_UNLOCK (object);
+    bin->priv->children_hash = NULL;
   }
 
   if (G_UNLIKELY (bin->children != NULL)) {
     g_critical ("could not remove elements from bin '%s'",
         GST_STR_NULL (GST_OBJECT_NAME (object)));
-  }
-
-  if (bin->priv->children_hash != NULL) {
-    g_hash_table_destroy (bin->priv->children_hash);
-    bin->priv->children_hash = NULL;
   }
 
   G_OBJECT_CLASS (parent_class)->dispose (object);
@@ -4457,10 +4461,12 @@ gst_bin_get_by_name (GstBin * bin, const gchar * name)
 
   if (bin->priv->children_hash != NULL) {
     /* Can use the hash for lookup */
+    GST_OBJECT_LOCK (bin);
     element = g_hash_table_lookup (bin->priv->children_hash, name);
     if (element) {
       gst_object_ref (element);
     }
+    GST_OBJECT_UNLOCK (bin);
   } else {
     /* Need to iterate the list for lookup */
     GstIterator *children;


### PR DESCRIPTION
Add extra locks around hash usage.

We also do not want the possibility of the pad being cleaned up before we go to find the name which we need to remove it from the hash.

Fixes #40548

(cherry picked from commit d67c7e1a87ab2292ae2ca8cc4e213f0ad0d080a5)