### PR TITLE
plugins-good/rtpsession: Add "enable-twcc-events" parameter.

### DIFF
--- a/subprojects/gst-plugins-good/gst/rtpmanager/gstrtpsession.c
+++ b/subprojects/gst-plugins-good/gst/rtpmanager/gstrtpsession.c
@@ -231,6 +231,7 @@ enum
 #define DEFAULT_RTCP_SYNC_SEND_TIME  TRUE
 #define DEFAULT_UPDATE_NTP64_HEADER_EXT  TRUE
 #define DEFAULT_TIMEOUT_INACTIVE_SOURCES TRUE
+#define DEFAULT_ENABLE_TWCC_PACKET_EVENT TRUE
 
 enum
 {
@@ -250,6 +251,7 @@ enum
   PROP_MAX_MISORDER_TIME,
   PROP_STATS,
   PROP_TWCC_STATS,
+  PROP_SEND_TWCC_PACKET_EVENT,
   PROP_RTP_PROFILE,
   PROP_NTP_TIME_SOURCE,
   PROP_RTCP_SYNC_SEND_TIME,
@@ -294,6 +296,8 @@ struct _GstRtpSessionPrivate
   guint sent_rtx_req_count;
 
   GstStructure *last_twcc_stats;
+
+  gboolean enable_twcc_packets_events;
 
   /*
    * This is the list of processed packets in the receive path when upstream
@@ -827,6 +831,11 @@ gst_rtp_session_class_init (GstRtpSessionClass * klass)
           "Various statistics from TWCC", GST_TYPE_STRUCTURE,
           G_PARAM_READABLE | G_PARAM_STATIC_STRINGS));
 
+  g_object_class_install_property (gobject_class, PROP_SEND_TWCC_PACKET_EVENT,
+      g_param_spec_boolean ("enable-twcc-packet-event", "Enable TWCC Packet Event",
+          "Allow the rtpsession to send upstream TWCC packet event.",
+          DEFAULT_ENABLE_TWCC_PACKET_EVENT, G_PARAM_READWRITE | G_PARAM_STATIC_STRINGS));
+
   g_object_class_install_property (gobject_class, PROP_RTP_PROFILE,
       g_param_spec_enum ("rtp-profile", "RTP Profile",
           "RTP profile to use", GST_TYPE_RTP_PROFILE, DEFAULT_RTP_PROFILE,
@@ -933,6 +942,7 @@ gst_rtp_session_init (GstRtpSession * rtpsession)
   rtpsession->priv->session = rtp_session_new ();
   rtpsession->priv->use_pipeline_clock = DEFAULT_USE_PIPELINE_CLOCK;
   rtpsession->priv->rtcp_sync_send_time = DEFAULT_RTCP_SYNC_SEND_TIME;
+  rtpsession->priv->enable_twcc_packets_events = DEFAULT_ENABLE_TWCC_PACKET_EVENT;
 
   /* configure callbacks */
   rtp_session_set_callbacks (rtpsession->priv->session, &callbacks, rtpsession);
@@ -1061,6 +1071,9 @@ gst_rtp_session_set_property (GObject * object, guint prop_id,
       g_object_set_property (G_OBJECT (priv->session),
           "timeout-inactive-sources", value);
       break;
+    case PROP_SEND_TWCC_PACKET_EVENT:
+      priv->enable_twcc_packets_events = g_value_get_boolean (value);
+      break;
     default:
       G_OBJECT_WARN_INVALID_PROPERTY_ID (object, prop_id, pspec);
       break;
@@ -1130,6 +1143,9 @@ gst_rtp_session_get_property (GObject * object, guint prop_id,
       GST_RTP_SESSION_LOCK (rtpsession);
       g_value_set_boxed (value, priv->last_twcc_stats);
       GST_RTP_SESSION_UNLOCK (rtpsession);
+      break;
+    case PROP_SEND_TWCC_PACKET_EVENT:
+      g_value_set_boolean (value, priv->enable_twcc_packets_events);
       break;
     case PROP_RTP_PROFILE:
       g_object_get_property (G_OBJECT (priv->session), "rtp-profile", value);
@@ -3043,7 +3059,7 @@ gst_rtp_session_notify_twcc (RTPSession * sess,
   rtpsession->priv->last_twcc_stats = twcc_stats;
   GST_RTP_SESSION_UNLOCK (rtpsession);
 
-  if (send_rtp_sink) {
+  if (send_rtp_sink && rtpsession->priv->enable_twcc_packets_events) {
     event = gst_event_new_custom (GST_EVENT_CUSTOM_UPSTREAM, twcc_packets);
     gst_pad_push_event (send_rtp_sink, event);
     gst_object_unref (send_rtp_sink);

--- a/subprojects/gst-plugins-good/tests/check/elements/rtpsession.c
+++ b/subprojects/gst-plugins-good/tests/check/elements/rtpsession.c
@@ -4937,6 +4937,43 @@ GST_START_TEST (test_twcc_recv_rtcp_reordered)
 
 GST_END_TEST;
 
+GST_START_TEST (test_twcc_packet_event)
+{
+  SessionHarness *send_h = session_harness_new ();
+  gboolean enabled_twcc_event = __i__;
+  g_object_set (send_h->session, "enable-twcc-packet-event", enabled_twcc_event, NULL);
+  SessionHarness *recv_h = session_harness_new ();
+  GstBuffer *buf;
+  GstEvent *event;
+  guint i;
+
+  TWCCPacket packets[] = {
+    {1, 1 * GST_SECOND, FALSE},
+    {2, 2 * GST_SECOND, TRUE},
+  };
+
+  twcc_push_packets (recv_h, packets);
+
+  buf = session_harness_produce_twcc (recv_h);
+  session_harness_recv_rtcp (send_h, buf);
+
+  for (i = 0; i < 2; i++)
+    gst_event_unref (gst_harness_pull_upstream_event (send_h->send_rtp_h));
+
+  if (enabled_twcc_event) {
+    event = gst_harness_try_pull_upstream_event (send_h->send_rtp_h);
+    twcc_verify_packets_to_event (packets, event);
+  } else {
+    event = gst_harness_try_pull_upstream_event (send_h->send_rtp_h);
+    fail_unless (event == NULL);
+  }
+
+  session_harness_free (send_h);
+  session_harness_free (recv_h);
+}
+
+GST_END_TEST;
+
 GST_START_TEST (test_twcc_no_exthdr_in_buffer)
 {
   SessionHarness *h = session_harness_new ();
@@ -6128,7 +6165,7 @@ GST_START_TEST (test_sender_timeout)
     fail_unless_equals_int (GST_FLOW_OK, res);
     session_harness_crank_clock (h);
   }
-  
+
   /* expect no timeout yet */
   fail_unless_equals_int (0, h->timeout_sender_ssrc);
 
@@ -6228,6 +6265,7 @@ rtpsession_suite (void)
   tcase_add_test (tc_chain, test_twcc_reordering_send_recv);
   tcase_add_test (tc_chain, test_twcc_recv_late_packet_fb_pkt_count_wrap);
   tcase_add_test (tc_chain, test_twcc_recv_rtcp_reordered);
+  tcase_add_loop_test (tc_chain, test_twcc_packet_event, 0, 2);
   tcase_add_test (tc_chain, test_twcc_no_exthdr_in_buffer);
   tcase_add_test (tc_chain, test_twcc_send_and_recv);
   tcase_add_test (tc_chain, test_twcc_multiple_payloads_below_window);


### PR DESCRIPTION
There might be cases where the application wants to disable the generation of TWCC events. This patch adds a new parameter "enable-twcc-events" to the rtpsession element. If this parameter is set to FALSE, the rtpsession element will not generate TWCC events. Default value is set to TRUE to maintain the current behavior.