### PR TITLE
rtpvp9pay: fix profile parsing (take 2)

### DIFF
--- a/subprojects/gst-plugins-good/gst/rtp/gstrtpvp9pay.c
+++ b/subprojects/gst-plugins-good/gst/rtp/gstrtpvp9pay.c
@@ -295,8 +295,11 @@ gst_rtp_vp9_pay_parse_frame (GstRtpVP9Pay * self, GstBuffer * buffer,
     goto error;
 
   /* profile, variable length */
-  if (!gst_bit_reader_get_bits_uint32 (&reader, &profile, 2))
+  guint8 version, high;
+  if (!(gst_bit_reader_get_bits_uint8 (&reader, &version, 1) &&
+        gst_bit_reader_get_bits_uint8 (&reader, &high, 1)))
     goto error;
+  profile = (high << 1) + version;
   if (profile > 2) {
     if (!gst_bit_reader_get_bits_uint32 (&reader, &tmp, 1))
       goto error;


### PR DESCRIPTION
Incorrect parsing of these bits meant that we were incorrectly parsing the VP9 uncompressed bitstream header for some profiles, as the header is of variable length and format depending on the profile. Amongst various unintended effects, this caused the width and height from the SS to be incorrectly parsed and set in the caps.

Co-authored-by: Camilo Celis Guzman <camilo@pexip.com>