### PR TITLE
mfvideosrc: attempt to unlock ReadSample() in gst_mf_source_reader_un…

### DIFF
--- a/subprojects/gst-plugins-bad/sys/mediafoundation/gstmfsourcereader.cpp
+++ b/subprojects/gst-plugins-bad/sys/mediafoundation/gstmfsourcereader.cpp
@@ -498,6 +498,13 @@ gst_mf_source_reader_read_sample (GstMFSourceReader * self)
   hr = self->reader->ReadSample (type->stream_index, 0, nullptr, &stream_flags,
       nullptr, &sample);
 
+  if (hr == MF_E_NOTACCEPTING) {
+    /* unlock() called Flush() on the reader */
+    g_assert (!sample);
+    GST_DEBUG_OBJECT (self, "ReadSample returned MF_E_NOTACCEPTING, flushing");
+    return GST_FLOW_FLUSHING;
+  }
+
   if (!gst_mf_result (hr)) {
     GST_ERROR_OBJECT (self, "Failed to read sample");
     return GST_FLOW_ERROR;
@@ -730,6 +737,13 @@ gst_mf_source_reader_unlock (GstMFSourceObject * object)
   GstMFSourceReader *self = GST_MF_SOURCE_READER (object);
 
   g_mutex_lock (&self->lock);
+
+  GstMFStreamMediaType *type = self->cur_type;
+  if (self->reader) {
+    HRESULT hr = self->reader->Flush (type->stream_index);
+    GST_LOG_OBJECT (self, "Flush() returned: %u", hr);
+  }
+
   self->flushing = TRUE;
   g_mutex_unlock (&self->lock);
 


### PR DESCRIPTION
…lock()

by calling Flush() on the reader

This change allows us to unblock the source thread that could be locked for a long time waiting for ReadSample() to finish.