### PR TITLE
mediafoundation/mfsourcereader: make sure we protect the queue with the lock

### DIFF
--- a/subprojects/gst-plugins-bad/sys/mediafoundation/gstmfvideosrc.cpp
+++ b/subprojects/gst-plugins-bad/sys/mediafoundation/gstmfvideosrc.cpp
@@ -359,7 +359,7 @@ gst_mf_video_src_set_caps (GstBaseSrc * src, GstCaps * caps)
 {
   GstMFVideoSrc *self = GST_MF_VIDEO_SRC (src);
 
-  GST_DEBUG_OBJECT (self, "Set caps %" GST_PTR_FORMAT, caps);
+  GST_INFO_OBJECT (self, "Set caps %" GST_PTR_FORMAT, caps);
 
   if (!self->source) {
     GST_ERROR_OBJECT (self, "No capture engine yet");


### PR DESCRIPTION
Fixes potential queue data-races when calling unlock and unlock_stop while the src is pushing buffers.
This also prepares the terrain to move the mfsourcereader to use the mediafoundation async API if we at some point need to.