### PR TITLE
mediafoundation/mfsourcereader: bail out on reading samples if the

### DIFF
--- a/subprojects/gst-plugins-bad/sys/mediafoundation/gstmfsourcereader.cpp
+++ b/subprojects/gst-plugins-bad/sys/mediafoundation/gstmfsourcereader.cpp
@@ -560,7 +560,7 @@ gst_mf_source_reader_get_media_buffer (GstMFSourceReader * self,
   *duration = GST_CLOCK_TIME_NONE;
 
   g_mutex_lock (&self->lock);
-  while (gst_vec_deque_is_empty (self->queue) && !self->flushing) {
+  while (gst_vec_deque_is_empty (self->queue) && !self->flushing && ret == GST_FLOW_OK) {
     ret = gst_mf_source_reader_read_sample (self);
   }
 


### PR DESCRIPTION
return code is an error

This allows us to bail immediately if the source reader becomes unavailable. One common example is if the user disconnects the camera in use, the source reader could fail with: "0xc00d3ea2, The video recording device is no longer present." Without this change, the source will hot loop until its stopped in such case.