### PR TITLE
sctp: fixes for state/socket handling during reconnect

### DIFF
--- a/subprojects/gst-plugins-bad/ext/sctp/dcsctp/net/dcsctp/public/dcsctp_socket.h
+++ b/subprojects/gst-plugins-bad/ext/sctp/dcsctp/net/dcsctp/public/dcsctp_socket.h
@@ -610,6 +610,8 @@ class DcSctpSocketInterface {
       webrtc::ArrayView<DcSctpMessage> messages,
       const SendOptions& send_options) = 0;
 
+  virtual void SendAbort(const char *message) = 0;
+
   // Resetting streams is an asynchronous operation and the results will
   // be notified using `DcSctpSocketCallbacks::OnStreamsResetDone()` on success
   // and `DcSctpSocketCallbacks::OnStreamsResetFailed()` on failure. Note that

--- a/subprojects/gst-plugins-bad/ext/sctp/dcsctp/net/dcsctp/socket/dcsctp_socket.h
+++ b/subprojects/gst-plugins-bad/ext/sctp/dcsctp/net/dcsctp/socket/dcsctp_socket.h
@@ -75,6 +75,7 @@ class DcSctpSocket : public DcSctpSocketInterface {
   void Close() override;
   SendStatus Send(DcSctpMessage message,
                   const SendOptions& send_options) override;
+  void SendAbort(const char *message) override;
   std::vector<SendStatus> SendMany(webrtc::ArrayView<DcSctpMessage> messages,
                                    const SendOptions& send_options) override;
   ResetStreamsStatus ResetStreams(

--- a/subprojects/gst-plugins-bad/ext/sctp/dcsctp/sctpsocket.cc
+++ b/subprojects/gst-plugins-bad/ext/sctp/dcsctp/sctpsocket.cc
@@ -417,6 +417,14 @@ sctp_socket_send (SctpSocket * socket, const uint8_t * data, size_t len, uint16_
   return static_cast<SctpSocket_SendStatus> (status);
 }
 
+void
+sctp_socket_send_abort (SctpSocket * socket, const char *message)
+{
+  assert (socket);
+  assert (socket->socket_);
+  socket->socket_->SendAbort (message);
+}
+
 SctpSocket_ResetStreamStatus
 sctp_socket_reset_streams (SctpSocket * socket, const uint16_t * streams, size_t len)
 {

--- a/subprojects/gst-plugins-bad/ext/sctp/dcsctp/sctpsocket.h
+++ b/subprojects/gst-plugins-bad/ext/sctp/dcsctp/sctpsocket.h
@@ -264,6 +264,8 @@ extern "C"
                                           uint32_t ppid, bool unordered, int32_t * lifetime,
                                           size_t * max_retransmissions);
 
+  void sctp_socket_send_abort (SctpSocket * socket, const char *message);
+
   // Resetting streams is an asynchronous operation and the results will
   // be notified using `DcSctpSocketCallbacks::OnStreamsResetDone()` on success
   // and `DcSctpSocketCallbacks::OnStreamsResetFailed()` on failure. Note that

--- a/subprojects/gst-plugins-bad/ext/sctp/gstsctpenc.c
+++ b/subprojects/gst-plugins-bad/ext/sctp/gstsctpenc.c
@@ -56,6 +56,7 @@ enum
   SIGNAL_GET_STREAM_BYTES_SENT,
   SIGNAL_DISCONNECT,
   SIGNAL_RECONNECT,
+  SIGNAL_SEND_ABORT,
   NUM_SIGNALS
 };
 
@@ -181,6 +182,7 @@ static void get_config_from_caps (const GstCaps * caps, gboolean * ordered,
 static guint64 on_get_stream_bytes_sent (GstSctpEnc * self, guint stream_id);
 static gboolean disconnect (GstSctpEnc * self);
 static void reconnect (GstSctpEnc * self);
+static void send_abort (GstSctpEnc * self, gchar *message);
 
 static void
 gst_sctp_enc_class_init (GstSctpEncClass * klass)
@@ -260,10 +262,16 @@ gst_sctp_enc_class_init (GstSctpEncClass * klass)
       G_STRUCT_OFFSET (GstSctpEncClass, reconnect), NULL, NULL,
       g_cclosure_marshal_generic, G_TYPE_NONE, 0);
 
+  signals[SIGNAL_SEND_ABORT] = g_signal_new ("send-abort",
+      G_TYPE_FROM_CLASS (gobject_class), G_SIGNAL_RUN_LAST | G_SIGNAL_ACTION,
+      G_STRUCT_OFFSET (GstSctpEncClass, send_abort), NULL, NULL,
+      g_cclosure_marshal_VOID__STRING, G_TYPE_NONE, 1, G_TYPE_STRING);
+
   klass->on_get_stream_bytes_sent =
       GST_DEBUG_FUNCPTR (on_get_stream_bytes_sent);
   klass->disconnect = GST_DEBUG_FUNCPTR (disconnect);
   klass->reconnect = GST_DEBUG_FUNCPTR (reconnect);
+  klass->send_abort = GST_DEBUG_FUNCPTR (send_abort);
 
   gst_element_class_set_static_metadata (element_class,
       "SCTP Encoder",
@@ -986,6 +994,21 @@ reconnect (GstSctpEnc * self)
   }
 
   gst_sctp_association_connect (self->sctp_association);
+  GST_SCTP_ENC_ASSOC_MUTEX_UNLOCK (self);
+}
+
+static void
+send_abort (GstSctpEnc * self, gchar *message)
+{
+  GST_SCTP_ENC_ASSOC_MUTEX_LOCK (self);
+
+  if (!self->sctp_association) {
+    GST_ERROR_OBJECT (self, "No GstSctpAssociation");
+    GST_SCTP_ENC_ASSOC_MUTEX_UNLOCK (self);
+    return;
+  }
+
+  gst_sctp_association_send_abort (self->sctp_association, message);
   GST_SCTP_ENC_ASSOC_MUTEX_UNLOCK (self);
 }
 

--- a/subprojects/gst-plugins-bad/ext/sctp/gstsctpenc.h
+++ b/subprojects/gst-plugins-bad/ext/sctp/gstsctpenc.h
@@ -74,6 +74,7 @@ struct _GstSctpEncClass
       guint stream_id);
   gboolean (*disconnect) (GstSctpEnc * sctp_enc);
   void (*reconnect) (GstSctpEnc * sctp_enc);
+  void (*send_abort) (GstSctpEnc * sctp_enc, gchar *message);
 };
 
 GType gst_sctp_enc_get_type (void);

--- a/subprojects/gst-plugins-bad/ext/sctp/sctpassociation.c
+++ b/subprojects/gst-plugins-bad/ext/sctp/sctpassociation.c
@@ -111,9 +111,6 @@ static void gst_sctp_association_change_state_unlocked (GstSctpAssociation *
 static void gst_sctp_association_cancel_pending_async (GstSctpAssociation *
     assoc);
 static gboolean force_close_async (GstSctpAssociation * assoc);
-static void
-gst_sctp_association_reset_stream_unlocked (GstSctpAssociation * assoc,
-    uint16_t stream_id);
 static gboolean
 gst_sctp_association_open_stream (GstSctpAssociation * assoc,
     guint16 stream_id);
@@ -223,6 +220,16 @@ gst_sctp_association_init (GstSctpAssociation * assoc)
   g_rec_mutex_init (GST_SCTP_ASSOC_GET_MUTEX (assoc));
 }
 
+// Must be called from GSource async handler
+static void
+gst_sctp_association_free_socket (GstSctpAssociation * assoc)
+{
+  if (assoc->socket) {
+    sctp_socket_free (assoc->socket);
+    assoc->socket = NULL;
+  }
+}
+
 static void
 gst_sctp_association_finalize (GObject * object)
 {
@@ -231,10 +238,7 @@ gst_sctp_association_finalize (GObject * object)
   /* we have to cleanup any attached sources we might have pending */
   gst_sctp_association_cancel_pending_async (assoc);
 
-  if (assoc->socket) {
-    sctp_socket_free (assoc->socket);
-    assoc->socket = NULL;
-  }
+  gst_sctp_association_free_socket (assoc);
 
   g_rec_mutex_clear (GST_SCTP_ASSOC_GET_MUTEX (assoc));
   g_hash_table_destroy (assoc->stream_id_to_state);
@@ -535,20 +539,6 @@ gst_sctp_association_on_connected (void *user_data)
   GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
 }
 
-static void
-gst_sctp_association_on_closed (void *user_data)
-{
-  GstSctpAssociation *assoc = user_data;
-
-  GST_SCTP_ASSOC_MUTEX_LOCK (assoc);
-  gst_sctp_association_change_state_unlocked (assoc,
-      GST_SCTP_ASSOCIATION_STATE_DISCONNECTED);
-  GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
-
-  g_assert (assoc->socket);
-  sctp_socket_free (assoc->socket);
-  assoc->socket = NULL;
-}
 
 static void
 gst_sctp_association_notify_restart (GstSctpAssociation * assoc)
@@ -615,6 +605,63 @@ gst_sctp_association_notify_stream_reset (GstSctpAssociation * assoc,
     gst_object_unref (user_data);
 }
 
+static const gchar *
+reset_stream_status_to_string (SctpSocket_ResetStreamStatus reset_status)
+{
+  switch (reset_status) {
+    case SCTP_SOCKET_RESET_STREAM_STATUS_NOT_CONNECTED:
+      return "Not connected";
+    case SCTP_SOCKET_RESET_STREAM_STATUS_PERFORMED:
+      return "Performed";
+    case SCTP_SOCKET_RESET_STREAM_STATUS_NOT_SUPPORTED:
+      return "Not supported";
+    default:
+      return "Unknown";
+  }
+}
+
+typedef struct
+{
+  GstSctpAssociation *assoc;
+  guint16 stream_id;
+} GstSctpAssociationResetStreamCtx;
+
+
+static gboolean
+gst_sctp_association_reset_stream_async (GstSctpAssociationResetStreamCtx * ctx)
+{
+  GstSctpAssociation *assoc = ctx->assoc;
+
+
+  GST_SCTP_ASSOC_MUTEX_LOCK (assoc);
+
+  GstSctpStreamState *state = g_hash_table_lookup (assoc->stream_id_to_state,
+      GUINT_TO_POINTER (ctx->stream_id));
+  if (!state) {
+    GST_WARNING_OBJECT (assoc, "Couldn't reset stream %u, not present",
+        ctx->stream_id);
+    return gst_sctp_association_async_return (assoc);
+  }
+
+  state->closure_initiated = TRUE;
+
+  if (assoc->socket) {
+    SctpSocket_ResetStreamStatus status =
+        sctp_socket_reset_streams (assoc->socket, &ctx->stream_id, 1);
+
+    GST_DEBUG_OBJECT (assoc, "Reset stream %u status: %s", ctx->stream_id,
+        reset_stream_status_to_string (status));
+
+  } else {
+    GST_LOG_OBJECT (assoc, "Couldn't reset stream %u, missing socket",
+        ctx->stream_id);
+  }
+
+  GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
+
+  return gst_sctp_association_async_return (assoc);
+}
+
 static void
 gst_sctp_association_handle_stream_reset (GstSctpAssociation * assoc,
     const uint16_t * streams, size_t len, gboolean incoming_reset)
@@ -642,7 +689,14 @@ gst_sctp_association_handle_stream_reset (GstSctpAssociation * assoc,
         // When receiving an incoming stream reset event for a non local close
         // procedure, the association needs to reset the stream in the other
         // direction too.
-        gst_sctp_association_reset_stream_unlocked (assoc, stream_id);
+        GstSctpAssociationResetStreamCtx *ctx =
+            g_new0 (GstSctpAssociationResetStreamCtx, 1);
+        ctx->assoc = assoc;
+        ctx->stream_id = stream_id;
+
+        gst_sctp_association_call_async (assoc, 0,
+            (GSourceFunc) gst_sctp_association_reset_stream_async,
+            ctx, (GDestroyNotify) g_free);
 
         // do not notify until we get the next reset notification from the socket
         notify_reset = FALSE;
@@ -845,6 +899,41 @@ gst_sctp_association_async_ctx_free (GstSctpAssociationAsyncContext * ctx)
   g_free (ctx);
 }
 
+
+static gboolean
+gst_sctp_association_on_closed_async (GstSctpAssociationAsyncContext *
+    ctx)
+{
+  GstSctpAssociation *assoc = ctx->assoc;
+
+  GST_SCTP_ASSOC_MUTEX_LOCK (assoc);
+  gst_sctp_association_change_state_unlocked (assoc,
+      GST_SCTP_ASSOCIATION_STATE_DISCONNECTED);
+  GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
+
+  gst_sctp_association_free_socket (assoc);
+
+  return gst_sctp_association_async_return (assoc);
+}
+
+static void
+gst_sctp_association_on_closed (void *user_data)
+{
+  GstSctpAssociation *assoc = user_data;
+
+  GstSctpAssociationAsyncContext *ctx =
+      g_new0 (GstSctpAssociationAsyncContext, 1);
+  ctx->assoc = assoc;
+
+  GST_SCTP_ASSOC_MUTEX_LOCK (assoc);
+
+  gst_sctp_association_call_async (assoc, 0,
+      (GSourceFunc) gst_sctp_association_on_closed_async,
+      ctx, (GDestroyNotify) gst_sctp_association_async_ctx_free);
+
+  GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
+}
+
 static gboolean
 gst_sctp_association_connect_async (GstSctpAssociation * assoc)
 {
@@ -921,6 +1010,8 @@ gst_sctp_association_incoming_packet_async (GstSctpAssociationAsyncContext *
 {
   GstSctpAssociation *assoc = ctx->assoc;
 
+  // We could receive a packet from DTLS-RTP via sctpdec before sctpenc has set
+  // up our socket.
   if (assoc->socket) {
     sctp_socket_receive_packet (assoc->socket, (uint8_t *) ctx->data,
         (size_t) ctx->len);
@@ -952,29 +1043,18 @@ send_status_to_string (SctpSocket_SendStatus send_status)
   }
 }
 
-static const gchar *
-reset_stream_status_to_string (SctpSocket_ResetStreamStatus reset_status)
-{
-  switch (reset_status) {
-    case SCTP_SOCKET_RESET_STREAM_STATUS_NOT_CONNECTED:
-      return "Not connected";
-    case SCTP_SOCKET_RESET_STREAM_STATUS_PERFORMED:
-      return "Performed";
-    case SCTP_SOCKET_RESET_STREAM_STATUS_NOT_SUPPORTED:
-      return "Not supported";
-    default:
-      return "Unknown";
-  }
-}
 
 static gboolean
 gst_sctp_association_send_abort_async (GstSctpAssociationAsyncContext * ctx)
 {
   GstSctpAssociation *assoc = ctx->assoc;
   g_assert (assoc);
-  g_assert (assoc->socket);
-
-  sctp_socket_send_abort (assoc->socket, (const char *) ctx->data);
+  if (assoc->socket) {
+    sctp_socket_send_abort (assoc->socket, (const char *) ctx->data);
+  } else {
+    GST_WARNING_OBJECT (ctx->assoc,
+        "Couldn't send abort, missing socket");
+  }
 
   return gst_sctp_association_async_return (assoc);
 }
@@ -984,7 +1064,12 @@ gst_sctp_association_send_data_async (GstSctpAssociationAsyncContext * ctx)
 {
   GstSctpAssociation *assoc = ctx->assoc;
   g_assert (assoc);
-  g_assert (assoc->socket);
+  if (!assoc->socket) {
+    GST_WARNING_OBJECT (ctx->assoc,
+        "Couldn't send data (%p with length %" G_GSIZE_FORMAT
+        "), missing socket", ctx->data, ctx->len);
+    return gst_sctp_association_async_return (assoc);
+  }
 
   int32_t *lifetime = NULL;
   size_t *max_retransmissions = NULL;
@@ -1029,9 +1114,8 @@ force_close_async (GstSctpAssociation * assoc)
 
   if (assoc->socket) {
     sctp_socket_close (assoc->socket);
-    sctp_socket_free (assoc->socket);
-    assoc->socket = NULL;
   }
+  gst_sctp_association_free_socket (assoc);
 
   GST_SCTP_ASSOC_MUTEX_LOCK (assoc);
   gst_sctp_association_change_state_unlocked (assoc,
@@ -1049,8 +1133,11 @@ gst_sctp_association_disconnect_async (GstSctpAssociation * assoc)
       GST_SCTP_ASSOCIATION_STATE_DISCONNECTING);
   GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
 
-  g_assert (assoc->socket);
-  sctp_socket_shutdown (assoc->socket);
+  if (assoc->socket) {
+    sctp_socket_shutdown (assoc->socket);
+  } else {
+    GST_WARNING_OBJECT (assoc, "Couldn't disconnect association; no socket");
+  }
 
   return gst_sctp_association_async_return (assoc);
 }
@@ -1140,18 +1227,6 @@ gst_sctp_association_send_abort (GstSctpAssociation * assoc,
     const gchar * message)
 {
   GST_SCTP_ASSOC_MUTEX_LOCK (assoc);
-  if (assoc->state != GST_SCTP_ASSOCIATION_STATE_CONNECTED) {
-    if (assoc->state == GST_SCTP_ASSOCIATION_STATE_DISCONNECTED ||
-        assoc->state == GST_SCTP_ASSOCIATION_STATE_DISCONNECTING) {
-      GST_INFO_OBJECT (assoc, "Disconnected");
-      GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
-      return;
-    } else {
-      GST_ERROR_OBJECT (assoc, "Association not connected yet");
-      GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
-      return;
-    }
-  }
 
   GstSctpAssociationAsyncContext *ctx =
       g_new0 (GstSctpAssociationAsyncContext, 1);
@@ -1172,18 +1247,6 @@ gst_sctp_association_send_data (GstSctpAssociation * assoc, const guint8 * buf,
     guint32 * bytes_sent_)
 {
   GST_SCTP_ASSOC_MUTEX_LOCK (assoc);
-  if (assoc->state != GST_SCTP_ASSOCIATION_STATE_CONNECTED) {
-    if (assoc->state == GST_SCTP_ASSOCIATION_STATE_DISCONNECTED ||
-        assoc->state == GST_SCTP_ASSOCIATION_STATE_DISCONNECTING) {
-      GST_INFO_OBJECT (assoc, "Disconnected");
-      GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
-      return GST_FLOW_EOS;
-    } else {
-      GST_ERROR_OBJECT (assoc, "Association not connected yet");
-      GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
-      return GST_FLOW_ERROR;
-    }
-  }
 
   if (!gst_sctp_association_open_stream (assoc, stream_id)) {
     GST_INFO_OBJECT (assoc,
@@ -1215,52 +1278,6 @@ gst_sctp_association_send_data (GstSctpAssociation * assoc, const guint8 * buf,
   return GST_FLOW_OK;
 }
 
-typedef struct
-{
-  GstSctpAssociation *assoc;
-  guint16 stream_id;
-} GstSctpAssociationResetStreamCtx;
-
- // call from the context thread holding a lock on association_mutex
-static void
-gst_sctp_association_reset_stream_unlocked (GstSctpAssociation * assoc,
-    uint16_t stream_id)
-{
-  GstSctpStreamState *state = g_hash_table_lookup (assoc->stream_id_to_state,
-      GUINT_TO_POINTER (stream_id));
-  if (!state) {
-    GST_WARNING_OBJECT (assoc, "Couldn't reset stream %u, not present",
-        stream_id);
-    return;
-  }
-
-  state->closure_initiated = TRUE;
-
-  if (assoc->socket) {
-    SctpSocket_ResetStreamStatus status =
-        sctp_socket_reset_streams (assoc->socket, &stream_id, 1);
-
-    GST_DEBUG_OBJECT (assoc, "Reset stream %u status: %s", stream_id,
-        reset_stream_status_to_string (status));
-
-  } else {
-    GST_LOG_OBJECT (assoc, "Couldn't reset stream %u, missing socket",
-        stream_id);
-  }
-}
-
-static gboolean
-gst_sctp_association_reset_stream_async (GstSctpAssociationResetStreamCtx * ctx)
-{
-  GstSctpAssociation *assoc = ctx->assoc;
-
-  GST_SCTP_ASSOC_MUTEX_LOCK (assoc);
-  gst_sctp_association_reset_stream_unlocked (assoc, ctx->stream_id);
-  GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
-
-  return gst_sctp_association_async_return (assoc);
-}
-
 void
 gst_sctp_association_reset_stream (GstSctpAssociation * assoc,
     guint16 stream_id)
@@ -1270,13 +1287,11 @@ gst_sctp_association_reset_stream (GstSctpAssociation * assoc,
     if (assoc->state == GST_SCTP_ASSOCIATION_STATE_DISCONNECTED ||
         assoc->state == GST_SCTP_ASSOCIATION_STATE_DISCONNECTING) {
       GST_INFO_OBJECT (assoc, "Disconnected");
-      GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
-      return;
     } else {
       GST_ERROR_OBJECT (assoc, "Association not connected yet");
-      GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
-      return;
     }
+    GST_SCTP_ASSOC_MUTEX_UNLOCK (assoc);
+    return;
   }
 
   GstSctpStreamState *state = g_hash_table_lookup (assoc->stream_id_to_state,

--- a/subprojects/gst-plugins-bad/ext/sctp/sctpassociation.h
+++ b/subprojects/gst-plugins-bad/ext/sctp/sctpassociation.h
@@ -71,7 +71,7 @@ typedef void (*GstSctpAssociationPacketOutCb) (const guint8 * data, gsize length
 typedef void (*GstSctpAssociationStateChangeCb) (GstSctpAssociation *
     sctp_association, GstSctpAssociationState state, gpointer user_data);
 
-struct _GstSctpAssociationEncoderCtx 
+struct _GstSctpAssociationEncoderCtx
 {
   gpointer element;
   GstSctpAssociationStateChangeCb state_change_cb;
@@ -85,7 +85,7 @@ typedef void (*GstSctpAssociationStreamResetCb)(guint16 stream_id, gpointer user
 
 typedef void (*GstSctpAssociationRestartCb)(gpointer user_data);
 
-struct _GstSctpAssociationDecoderCtx 
+struct _GstSctpAssociationDecoderCtx
 {
   gpointer element;
   GstSctpAssociationPacketReceivedCb packet_received_cb;
@@ -136,7 +136,7 @@ GType gst_sctp_association_get_type (void);
 
 gboolean gst_sctp_association_connect (GstSctpAssociation * self);
 
-void gst_sctp_association_set_encoder_ctx (GstSctpAssociation * self, 
+void gst_sctp_association_set_encoder_ctx (GstSctpAssociation * self,
     GstSctpAssociationEncoderCtx * ctx);
 void gst_sctp_association_set_decoder_ctx (GstSctpAssociation * self,
     GstSctpAssociationDecoderCtx * ctx);
@@ -147,6 +147,8 @@ GstFlowReturn gst_sctp_association_send_data (GstSctpAssociation * self,
     const guint8 * buf, guint32 length, guint16 stream_id, guint32 ppid,
     gboolean ordered, GstSctpAssociationPartialReliability pr,
     guint32 reliability_param, guint32 *bytes_sent);
+void gst_sctp_association_send_abort (GstSctpAssociation * assoc,
+    const gchar * message);
 void gst_sctp_association_reset_stream (GstSctpAssociation * self,
     guint16 stream_id);
 void gst_sctp_association_force_close (GstSctpAssociation * self);

--- a/subprojects/gst-plugins-bad/ext/sctp/sctpassociation.h
+++ b/subprojects/gst-plugins-bad/ext/sctp/sctpassociation.h
@@ -112,6 +112,8 @@ struct _GstSctpAssociation
   guint16 remote_port;
   gboolean use_sock_stream;
   gboolean aggressive_heartbeat;
+
+  // Must only be accessed from GSource async handlers
   SctpSocket * socket;
 
   GRecMutex association_mutex;


### PR DESCRIPTION
```
commit 11501fa4a8f01ddc402b9041c1f216ef9cd3726f
Author: Will Miller <will.miller@pexip.com>
Date:   Wed Jul 9 13:02:40 2025 +0100

    plugins-bad/sctp: remove unnecessary state checks in sctpenc

    These checks are no longer required because the underlying dcsctp
    library performs send queueing and doesn't need to be protected from
    calling the methods early.

commit b07bdd3a8296f67fe208c6ad198b67ed051b0354
Author: Will Miller <will.miller@pexip.com>
Date:   Wed Jul 9 12:52:58 2025 +0100

    plugins-bad/sctp: more resilient association socket handling

    We can't assume the association's socket will always exist, as it gets
    torn down when we experience a force-close (due to a timeout, for
    example), or a client-received abort chunk. Remove assertions as to the
    state of the socket where we can't guarantee it, and replace them with
    conditionals. Additionally, ensure we only ever access the socket member
    from async handlers to give thread safety.

commit cf4927c43ac3c22b485a223fdada4585d252e356
Author: Will Miller <will.miller@pexip.com>
Date:   Fri Jun 20 14:48:38 2025 +0100

    sctp: add send-abort capability to sctpenc

    Allow directly sending a User-Initiated abort with a given string from
    the application level. This is useful to simulate scenarios of receiving
    such a chunk off the wire in a test, even when an implementation such as
    dcsctp might not natively ever provoke such a scenario.

```