### PR TITLE
[pexhack] gstreamer/gst: account for init lock type change

### DIFF
--- a/subprojects/gstreamer/gst/gst.c
+++ b/subprojects/gstreamer/gst/gst.c
@@ -1088,7 +1088,7 @@ gst_deinit (void)
   if (gst_deinitialized) {
     /* tell the user how naughty they've been */
     g_message ("GStreamer should not be deinitialized a second time.");
-    g_mutex_unlock (&init_lock);
+    g_rec_mutex_unlock (&init_lock);
     return;
   }
 


### PR DESCRIPTION
This is now a re-entrant mutex; so use to corresponding API

This was introduced in https://gitlab.freedesktop.org/gstreamer/gstreamer/-/merge_requests/2740 to avoid deadlocks on repeated initializations.

Fixup of d2742d3d50ea0944faa659734b1c924f2e364a2d