### PR TITLE
rtptwccstats: protect sent_packets ring buffer with mutex

### DIFF
--- a/subprojects/gst-plugins-good/gst/rtpmanager/rtptwccstats.c
+++ b/subprojects/gst-plugins-good/gst/rtpmanager/rtptwccstats.c
@@ -107,6 +107,7 @@ struct _TWCCStatsManager
   GstClockTime prev_stat_window_beginning;
 
   GstVecDeque *sent_packets;
+  GMutex sent_packets_lock;
   gsize sent_packets_size;
 
   /* Ring Buffer of pointers to SentPacket struct from sent_packets
@@ -129,6 +130,9 @@ struct _TWCCStatsManager
 
 static SentPacket *_find_sentpacket (TWCCStatsManager * statsman,
     guint16 seqnum);
+
+#define SENT_PKT_LOCK(statsman)  g_mutex_lock (&(statsman)->sent_packets_lock)
+#define SENT_PKT_UNLOCK(statsman)  g_mutex_unlock (&(statsman)->sent_packets_lock)
 
 /******************************************************************************/
 typedef GArray *RedBlockKey;
@@ -412,14 +416,25 @@ _keep_history_length (TWCCStatsManager * statsman, gsize max_len,
   }
 }
 
+
+/* Push new packet and/or evict all eligible entries if needed,
+ *   return pointer to the inserted element.
+ */
 static SentPacket *
 _sent_pkt_keep_length (TWCCStatsManager * statsman, gsize max_len,
-    SentPacket * new_packet)
+    SentPacket * new_packet, GstClockTime cur_time,
+    GstClockTime max_history_duration)
 {
-  _keep_history_length (statsman, max_len, GST_CLOCK_TIME_NONE,
-      GST_CLOCK_TIME_NONE);
-  gst_vec_deque_push_tail_struct (statsman->sent_packets, new_packet);
-  return (SentPacket *) gst_vec_deque_peek_tail_struct (statsman->sent_packets);
+  SentPacket *ret = NULL;
+  SENT_PKT_LOCK (statsman);
+  while (_keep_history_length (statsman, max_len, cur_time,
+          max_history_duration));
+  if (new_packet) {
+    gst_vec_deque_push_tail_struct (statsman->sent_packets, new_packet);
+    ret = (SentPacket *) gst_vec_deque_peek_tail_struct (statsman->sent_packets);
+  }
+  SENT_PKT_UNLOCK (statsman);
+  return ret;
 }
 
 static TWCCStatsCtx *
@@ -1389,6 +1404,7 @@ rtp_twcc_stats_manager_new (GObject * parent)
       (GDestroyNotify) g_hash_table_destroy);
   statsman->sent_packets = gst_vec_deque_new_for_struct (sizeof (SentPacket),
       PACKETS_HIST_LEN_DEFAULT);
+  g_mutex_init (&statsman->sent_packets_lock);
   statsman->sent_packets_size = PACKETS_HIST_LEN_DEFAULT;
   gst_vec_deque_set_clear_func (statsman->sent_packets,
       (GDestroyNotify) _free_sentpacket);
@@ -1419,6 +1435,7 @@ rtp_twcc_stats_manager_free (TWCCStatsManager * statsman)
 {
   g_hash_table_destroy (statsman->ssrc_to_seqmap);
   gst_vec_deque_free (statsman->sent_packets);
+  g_mutex_clear (&statsman->sent_packets_lock);
   gst_vec_deque_free (statsman->sent_packets_feedbacks);
   g_hash_table_destroy (statsman->stats_ctx_by_pt);
   g_hash_table_destroy (statsman->redund_2_redblocks);
@@ -1458,7 +1475,8 @@ rtp_twcc_stats_sent_pkt (TWCCStatsManager * statsman,
   /* Add packet to the sent_packets ring buffer and
      make sure that it is within max_size, if not shrink by 1 pkt */
   SentPacket *sent_pkt =
-      _sent_pkt_keep_length (statsman, statsman->sent_packets_size, &packet);
+      _sent_pkt_keep_length (statsman, statsman->sent_packets_size, &packet,
+      GST_CLOCK_TIME_NONE, GST_CLOCK_TIME_NONE);
   twcc_stats_ctx_add_packet (statsman, sent_pkt);
 
   for (guint i = 0; protect_seqnums_array && i < protect_seqnums_array->len;
@@ -1483,9 +1501,13 @@ void
 rtp_twcc_stats_set_sock_ts (TWCCStatsManager * statsman,
     guint16 seqnum, GstClockTime sock_ts)
 {
+  SENT_PKT_LOCK (statsman);
   SentPacket *pkt = _find_sentpacket (statsman, seqnum);
   if (pkt) {
     pkt->socket_ts = sock_ts;
+  }
+  SENT_PKT_UNLOCK (statsman);
+  if (pkt) {
     GST_LOG_OBJECT (statsman->parent,
         "packet #%u, setting socket-ts %" GST_TIME_FORMAT, seqnum,
         GST_TIME_ARGS (sock_ts));
@@ -1507,29 +1529,34 @@ rtp_twcc_stats_pkt_feedback (TWCCStatsManager * statsman,
     TWCCPktState status)
 {
   SentPacket *found;
+  gboolean updated = FALSE;
+
+  SENT_PKT_LOCK (statsman);
   if (!!(found = _find_sentpacket (statsman, seqnum))) {
     /* Do not process feedback on packets we have got feedback previously */
     if (found->status < status) {
       found->remote_ts = remote_ts;
       found->status = status;
-      gst_vec_deque_push_tail (statsman->sent_packets_feedbacks, found);
-      GST_LOG_OBJECT (statsman->parent,
-          "matching pkt: #%u with local_ts: %" GST_TIME_FORMAT
-          " size: %u, remote-ts: %" GST_TIME_FORMAT, seqnum,
-          GST_TIME_ARGS (found->local_ts), found->size * 8,
-          GST_TIME_ARGS (remote_ts));
-
-      /* calculate the round-trip time */
-      statsman->rtt = GST_CLOCK_DIFF (found->local_ts, current_time);
-    } else {
-      /* We've got feed back on the packet that was covered with the previous TWCC report.
-         Receiver could send two feedbacks on a single packet on purpose,
-         so we just ignore it. */
-      GST_LOG_OBJECT (statsman->parent,
-          "Rejecting second feedback on a packet #%u: current state: %s, "
-          "received fb: %s", seqnum, _pkt_status_s (found->status),
-          _pkt_status_s (status));
+      updated = TRUE;
     }
+  }
+  SENT_PKT_UNLOCK (statsman);
+
+  if (found && updated) {
+    gst_vec_deque_push_tail (statsman->sent_packets_feedbacks, found);
+    GST_LOG_OBJECT (statsman->parent,
+        "matching pkt: #%u with local_ts: %" GST_TIME_FORMAT
+        " size: %u, remote-ts: %" GST_TIME_FORMAT, seqnum,
+        GST_TIME_ARGS (found->local_ts), found->size * 8,
+        GST_TIME_ARGS (remote_ts));
+
+    /* calculate the round-trip time */
+    statsman->rtt = GST_CLOCK_DIFF (found->local_ts, current_time);
+  } else if (found && !updated) {
+    GST_LOG_OBJECT (statsman->parent,
+        "Rejecting second feedback on a packet #%u: current state: %s, "
+        "received fb: %s", seqnum, _pkt_status_s (found->status),
+        _pkt_status_s (status));
   } else {
     GST_WARNING_OBJECT (statsman->parent, "Feedback on unknown packet #%u",
         seqnum);
@@ -1569,8 +1596,8 @@ rtp_twcc_stats_do_stats (TWCCStatsManager * statsman,
     return twcc_stats_ctx_get_structure (statsman->stats_ctx);
 
   /* Prune old packets in stats */
-  while (_keep_history_length (statsman, statsman->sent_packets_size, last_ts,
-          PACKETS_HIST_DUR));
+  _sent_pkt_keep_length (statsman, statsman->sent_packets_size, NULL, last_ts,
+      PACKETS_HIST_DUR);
 
   array = g_value_array_new (0);
   end_time = GST_CLOCK_DIFF (stats_window_delay, last_ts);
@@ -1663,23 +1690,27 @@ rtp_twcc_stats_check_for_lost_packets (TWCCStatsManager * statsman,
   for (i = 0; i < packets_lost; i++) {
     const guint16 seqnum = statsman->expected_parsed_seqnum + i;
     SentPacket *found;
+    gboolean updated = FALSE;
+
+    SENT_PKT_LOCK (statsman);
     if (!!(found = _find_sentpacket (statsman, seqnum))) {
       /* Do not process feedback on packets we have got feedback previously */
       if (found->status == RTP_TWCC_FECBLOCK_PKT_UNKNOWN) {
         found->status = RTP_TWCC_FECBLOCK_PKT_LOST;
-        gst_vec_deque_push_tail (statsman->sent_packets_feedbacks, found);
-        GST_LOG_OBJECT (statsman->parent,
-            "Processing lost pkt feedback: #%u with local_ts: %" GST_TIME_FORMAT
-            " size: %u", seqnum,
-            GST_TIME_ARGS (found->local_ts), found->size * 8);
-
-      } else {
-        /* We've got feed back on the packet that was covered with the previous TWCC report.
-           Receiver could send two feedbacks on a single packet on purpose,
-           so we just ignore it. */
-        GST_LOG_OBJECT (statsman->parent,
-            "Rejecting second feedback on a packet #%u", seqnum);
+        updated = TRUE;
       }
+    }
+    SENT_PKT_UNLOCK (statsman);
+
+    if (found && updated) {
+      gst_vec_deque_push_tail (statsman->sent_packets_feedbacks, found);
+      GST_LOG_OBJECT (statsman->parent,
+          "Processing lost pkt feedback: #%u with local_ts: %" GST_TIME_FORMAT
+          " size: %u", seqnum,
+          GST_TIME_ARGS (found->local_ts), found->size * 8);
+    } else if (found) {
+      GST_LOG_OBJECT (statsman->parent,
+          "Rejecting second feedback on a packet #%u", seqnum);
     }
   }
 
@@ -1692,5 +1723,8 @@ done:
 guint
 rtp_twcc_stats_queue_len (TWCCStatsManager * stats_manager)
 {
-  return gst_vec_deque_get_length (stats_manager->sent_packets);
+  SENT_PKT_LOCK (stats_manager);
+  guint len = gst_vec_deque_get_length (stats_manager->sent_packets);
+  SENT_PKT_UNLOCK (stats_manager);
+  return len;
 }

--- a/subprojects/gst-plugins-good/tests/check/elements/rtpsession.c
+++ b/subprojects/gst-plugins-good/tests/check/elements/rtpsession.c
@@ -6886,6 +6886,151 @@ GST_START_TEST (test_twcc_seqnum_wrap_gap_detection)
 
 GST_END_TEST;
 
+/*
+ * Stress-test for the race between rtp_twcc_stats_sent_pkt() (called from the
+ * session thread under RTP_SESSION_LOCK) and rtp_twcc_stats_set_sock_ts()
+ * (called from the network sink thread via GstTxFeedback, WITHOUT
+ * RTP_SESSION_LOCK).
+ *
+ * Without the sent_packets_lock mutex the concurrent access to the
+ * sent_packets ring buffer causes _find_sentpacket() to occasionally return
+ * NULL, producing "Unable to update send-time for twcc-seqnum ..." warnings.
+ */
+static void
+_count_twcc_sock_ts_warns_log_func (GstDebugCategory * category,
+    GstDebugLevel level,
+    const gchar * file,
+    const gchar * function,
+    gint line, GObject * object, GstDebugMessage * message, gpointer user_data)
+{
+  (void) category;
+  (void) file;
+  (void) line;
+  (void) object;
+  (void) message;
+  if ((level == GST_LEVEL_ERROR || level == GST_LEVEL_WARNING) &&
+      function && strstr (function, "rtp_twcc_stats_set_sock_ts")) {
+    gint *count = user_data;
+    g_atomic_int_inc (count);
+  }
+}
+
+typedef struct
+{
+  GAsyncQueue *sent_bufs;       /* GstBuffer* with TxFeedbackMeta */
+  gint sender_done;             /* atomic flag */
+} TwccSetSockTsRaceCtx;
+
+static gpointer
+_twcc_set_sock_ts_race_feedback_thread (gpointer data)
+{
+  TwccSetSockTsRaceCtx *ctx = data;
+  while (TRUE) {
+    GstBuffer *buf =
+        g_async_queue_timeout_pop (ctx->sent_bufs, 100 * 1000);
+    if (buf) {
+      GstTxFeedbackMeta *meta = gst_buffer_get_tx_feedback_meta (buf);
+      if (meta)
+        gst_tx_feedback_meta_set_tx_time (meta, GST_MSECOND);
+      gst_buffer_unref (buf);
+    } else if (g_atomic_int_get (&ctx->sender_done)) {
+      /* Drain remaining buffers */
+      while ((buf = g_async_queue_try_pop (ctx->sent_bufs)) != NULL) {
+        GstTxFeedbackMeta *meta = gst_buffer_get_tx_feedback_meta (buf);
+        if (meta)
+          gst_tx_feedback_meta_set_tx_time (meta, GST_MSECOND);
+        gst_buffer_unref (buf);
+      }
+      break;
+    }
+  }
+  return NULL;
+}
+
+GST_START_TEST (test_twcc_set_sock_ts_race)
+{
+  SessionHarness *h;
+  gint logged_sock_ts_warnings = 0;
+  GstDebugLevel level;
+  GThread *feedback_thread = NULL;
+  TwccSetSockTsRaceCtx ctx = { NULL, FALSE };
+  guint i;
+  GstFlowReturn send_res;
+  gint final_warn_count;
+  /*
+   * The sent_packets ring buffer has a compile-time capacity of 30 000
+   * (MAX_STATS_PACKETS).  We first fill it up, then keep sending while a
+   * second thread concurrently calls gst_tx_feedback_meta_set_tx_time().
+   * Once the buffer is full every send evicts the oldest entry, changing
+   * the deque head — exactly the operation that races with
+   * _find_sentpacket() in the un-fixed code.
+   */
+  const guint warmup_packets = 30000;
+  const guint stress_packets = 5000;
+  const guint total_packets = warmup_packets + stress_packets;
+  h = session_harness_new ();
+  session_harness_add_twcc_caps_for_pt (h, TEST_BUF_PT);
+  gst_element_send_event (h->session, gst_event_new_latency (10 * GST_MSECOND));
+  level = gst_debug_get_default_threshold ();
+  gst_debug_set_default_threshold (GST_LEVEL_WARNING);
+  gst_debug_add_log_function (_count_twcc_sock_ts_warns_log_func,
+      &logged_sock_ts_warnings, NULL);
+  /* Phase 1: fill the ring buffer without concurrent feedback */
+  for (i = 0; i < warmup_packets; i++) {
+    GstBuffer *buf = generate_twcc_send_buffer (i, FALSE);
+    send_res = session_harness_send_rtp (h, buf);
+    if (send_res != GST_FLOW_OK)
+      goto SET_SOCK_TS_RACE_CLEAR;
+    buf = session_harness_pull_send_rtp (h);
+    gst_buffer_unref (buf);
+  }
+  /*
+   * Phase 2: keep sending packets (each one triggers an eviction + push in
+   * the ring buffer) while a feedback thread concurrently calls
+   * gst_tx_feedback_meta_set_tx_time(), which ends up in
+   * rtp_twcc_stats_set_sock_ts() → _find_sentpacket().
+   */
+  ctx.sent_bufs = g_async_queue_new ();
+  g_atomic_int_set (&ctx.sender_done, FALSE);
+  feedback_thread = g_thread_new ("tx-feedback",
+      _twcc_set_sock_ts_race_feedback_thread, &ctx);
+  for (i = warmup_packets; i < total_packets; i++) {
+    GstBuffer *buf = generate_twcc_send_buffer (i, i == total_packets - 1);
+    send_res = session_harness_send_rtp (h, buf);
+    if (send_res != GST_FLOW_OK)
+      goto SET_SOCK_TS_RACE_CLEAR;
+    buf = session_harness_pull_send_rtp (h);
+    g_async_queue_push (ctx.sent_bufs, buf);
+  }
+
+SET_SOCK_TS_RACE_CLEAR:
+  /* Signal the feedback thread to stop and join it before touching shared
+   * state so we can safely read the warning counter and tear down. */
+  g_atomic_int_set (&ctx.sender_done, TRUE);
+  if (feedback_thread)
+    g_thread_join (feedback_thread);
+
+  /* Always restore process-wide debug state — even on assertion failure. */
+  gst_debug_remove_log_function (_count_twcc_sock_ts_warns_log_func);
+  gst_debug_set_default_threshold (level);
+
+  if (ctx.sent_bufs)
+    g_async_queue_unref (ctx.sent_bufs);
+  session_harness_free (h);
+
+  /* Defer assertions to after cleanup so global state is always restored. */
+  fail_unless_equals_int64 (send_res, GST_FLOW_OK);
+  /*
+   * With the sent_packets_lock fix no "Unable to update send-time"
+   * warnings should appear.  Without the fix the concurrent ring buffer
+   * access causes _find_sentpacket() to occasionally miss a packet.
+   */
+  final_warn_count = g_atomic_int_get (&logged_sock_ts_warnings);
+  fail_unless_equals_int (final_warn_count, 0);
+}
+
+GST_END_TEST;
+
 GST_START_TEST (test_send_rtcp_instantly)
 {
   SessionHarness *h = session_harness_new ();
@@ -7482,6 +7627,7 @@ rtpsession_suite (void)
   */
   tcase_skip_broken_test (tc_chain, test_twcc_rtx_rtp_seqnum_wrap_corruption);
   tcase_add_test (tc_chain, test_twcc_seqnum_wrap_gap_detection);
+  tcase_add_test (tc_chain, test_twcc_set_sock_ts_race);
 
   tcase_add_test (tc_chain, test_send_rtcp_instantly);
   tcase_add_test (tc_chain, test_send_bye_signal);


### PR DESCRIPTION
rtp_twcc_stats_set_sock_ts() is called from the network sink thread via the GstTxFeedback callback, without RTP_SESSION_LOCK protection. This races with _keep_history_length() evictions and _sent_pkt_keep_length() insertions running under RTP_SESSION_LOCK on the session thread.

Add a GMutex (sent_packets_lock) to TWCCStatsManager and protect all sent_packets ring buffer access through it:

- _sent_pkt_keep_length(): locks internally, now handles both push mode (new_packet != NULL) and evict-all mode (new_packet == NULL), becoming the sole caller of _keep_history_length()
- _find_sentpacket(): callers (set_sock_ts, pkt_feedback, check_for_lost_packets) bracket find + field writes with explicit lock/unlock
- rtp_twcc_stats_queue_len(): locks internally

Lock ordering: RTP_SESSION_LOCK -> sent_packets_lock (never reversed). No blocking or other mutexes reachable inside locked sections.