### PR TITLE
plugins-good/rtpssrcdemux: keep SSRC pad state alive during pad removal

### DIFF
--- a/subprojects/gst-plugins-good/gst/rtpmanager/gstrtpssrcdemux.c
+++ b/subprojects/gst-plugins-good/gst/rtpmanager/gstrtpssrcdemux.c
@@ -547,13 +547,41 @@ gst_rtp_ssrc_demux_init (GstRtpSsrcDemux * demux)
   g_rec_mutex_init (&demux->padlock);
 }
 
+/* Remove the pads from the element while the corresponding dpads entry is
+ * still present in demux->srcpads.
+ *
+ * gst_element_remove_pad() can synchronously trigger pad deactivation,
+ * unlinking and event forwarding. Event forwarding may call
+ * gst_pad_iterate_internal_links() on one of these src pads while it is still
+ * externally referenced and still parented to this element. During that window
+ * gst_rtp_ssrc_demux_iterate_internal_links_src() must still be able to find
+ * the pad in demux->srcpads.
+ *
+ * MUST NOT be called with GST_OBJECT_LOCK (demux) held.
+ */
+static void
+gst_rtp_ssrc_demux_pads_remove_from_element (GstRtpSsrcDemux * demux,
+    GstRtpSsrcDemuxPads * dpads)
+{
+  GstPad *rtp_pad;
+  GstPad *rtcp_pad;
+
+  GST_DEBUG_OBJECT (demux, "Removing pads for ssrc %u", dpads->ssrc);
+
+  rtp_pad = gst_object_ref (dpads->rtp_pad);
+  rtcp_pad = gst_object_ref (dpads->rtcp_pad);
+
+  gst_element_remove_pad (GST_ELEMENT_CAST (demux), rtp_pad);
+  gst_element_remove_pad (GST_ELEMENT_CAST (demux), rtcp_pad);
+
+  gst_object_unref (rtp_pad);
+  gst_object_unref (rtcp_pad);
+}
+
 static void
 gst_rtp_ssrc_demux_pads_free (GstRtpSsrcDemuxPads * dpads)
 {
-  GST_DEBUG ("Freeing pads for ssrc %u", dpads->ssrc);
-
-  gst_element_remove_pad (GST_PAD_PARENT (dpads->rtp_pad), dpads->rtp_pad);
-  gst_element_remove_pad (GST_PAD_PARENT (dpads->rtcp_pad), dpads->rtcp_pad);
+  GST_DEBUG ("Freeing pad bookkeeping for ssrc %u", dpads->ssrc);
 
   g_free (dpads);
 }
@@ -561,9 +589,26 @@ gst_rtp_ssrc_demux_pads_free (GstRtpSsrcDemuxPads * dpads)
 static void
 gst_rtp_ssrc_demux_reset (GstRtpSsrcDemux * demux)
 {
-  g_slist_free_full (demux->srcpads,
-      (GDestroyNotify) gst_rtp_ssrc_demux_pads_free);
+  GSList *walk, *srcpads;
+
+  INTERNAL_STREAM_LOCK (demux);
+
+  /*
+   * Keep demux->srcpads intact while removing pads from the element.
+   * Pad removal can synchronously forward events and traverse internal links
+   * through pads that are still alive/parented during teardown.
+   */
+  for (walk = demux->srcpads; walk; walk = walk->next)
+    gst_rtp_ssrc_demux_pads_remove_from_element (demux, walk->data);
+
+  GST_OBJECT_LOCK (demux);
+  srcpads = demux->srcpads;
   demux->srcpads = NULL;
+  GST_OBJECT_UNLOCK (demux);
+
+  g_slist_free_full (srcpads, (GDestroyNotify) gst_rtp_ssrc_demux_pads_free);
+
+  INTERNAL_STREAM_UNLOCK (demux);
 }
 
 static void
@@ -607,16 +652,30 @@ gst_rtp_ssrc_demux_clear_ssrc (GstRtpSsrcDemux * demux, guint32 ssrc)
 
   GST_DEBUG_OBJECT (demux, "clearing pad for SSRC %08x", ssrc);
 
-  demux->srcpads = g_slist_remove (demux->srcpads, dpads);
+  /*
+   * Keep dpads in demux->srcpads while removing the pads from the element.
+   *
+   * gst_element_remove_pad() may synchronously trigger pad deactivation,
+   * unlinking and event forwarding. Event forwarding can call
+   * gst_pad_iterate_internal_links() on a still-live src pad. While the pad is
+   * still parented to this element, gst_rtp_ssrc_demux_iterate_internal_links_src()
+   * must be able to find its GstRtpSsrcDemuxPads entry.
+   */
   rtp_pad = gst_object_ref (dpads->rtp_pad);
   GST_OBJECT_UNLOCK (demux);
 
-  gst_rtp_ssrc_demux_pads_free (dpads);
+  gst_rtp_ssrc_demux_pads_remove_from_element (demux, dpads);
+
+  GST_OBJECT_LOCK (demux);
+  demux->srcpads = g_slist_remove (demux->srcpads, dpads);
+  GST_OBJECT_UNLOCK (demux);
 
   INTERNAL_STREAM_UNLOCK (demux);
 
   g_signal_emit (G_OBJECT (demux),
       gst_rtp_ssrc_demux_signals[SIGNAL_REMOVED_SSRC_PAD], 0, ssrc, rtp_pad);
+
+  gst_rtp_ssrc_demux_pads_free (dpads);
   gst_object_unref (rtp_pad);
 
   return;
@@ -1097,6 +1156,8 @@ gst_rtp_ssrc_demux_src_event (GstPad * pad, GstObject * parent,
 static GstIterator *
 gst_rtp_ssrc_demux_iterate_internal_links_src (GstPad * pad, GstObject * parent)
 {
+  g_return_val_if_fail (parent != NULL, NULL);
+
   GstRtpSsrcDemux *demux;
   GstPad *otherpad = NULL;
   GstIterator *it = NULL;

--- a/subprojects/gst-plugins-good/tests/check/elements/rtpssrcdemux.c
+++ b/subprojects/gst-plugins-good/tests/check/elements/rtpssrcdemux.c
@@ -989,6 +989,82 @@ GST_START_TEST (test_rtp_chain_list_empty)
 
 GST_END_TEST;
 
+typedef struct
+{
+  guint n_src_pads_checked;
+} PadRemovedInternalLinksCtx;
+
+static void
+pad_removed_iterate_internal_links_cb (GstElement * element, GstPad * pad,
+    PadRemovedInternalLinksCtx * ctx)
+{
+  GstIterator *iter;
+  GstIteratorResult res;
+  GValue item = G_VALUE_INIT;
+  GstPad *internal_pad;
+  const gchar *expected_name = NULL;
+
+  if (!GST_PAD_IS_SRC (pad))
+    return;
+
+  if (g_str_has_prefix (GST_PAD_NAME (pad), "src_"))
+    expected_name = "sink";
+  else if (g_str_has_prefix (GST_PAD_NAME (pad), "rtcp_src_"))
+    expected_name = "rtcp_sink";
+  else
+    return;
+
+  /*
+   * During gst_element_remove_pad(), the pad has already been removed from the
+   * element's src pad list, but is still parented until after the pad-removed
+   * signal has been emitted. rtpssrcdemux must keep its own SSRC pad
+   * bookkeeping alive during this window so internal-link traversal remains
+   * valid.
+   */
+  iter = gst_pad_iterate_internal_links (pad);
+  fail_unless (iter != NULL,
+      "Expected internal links iterator for pad %s during pad removal",
+      GST_PAD_NAME (pad));
+
+  res = gst_iterator_next (iter, &item);
+  fail_unless_equals_int (res, GST_ITERATOR_OK);
+
+  internal_pad = g_value_get_object (&item);
+  fail_unless (GST_IS_PAD (internal_pad));
+  fail_unless (!g_strcmp0 (GST_PAD_NAME (internal_pad), expected_name),
+      "Expected internal link from %s to %s, got %s",
+      GST_PAD_NAME (pad), expected_name, GST_PAD_NAME (internal_pad));
+
+  g_value_unset (&item);
+  gst_iterator_free (iter);
+
+  ctx->n_src_pads_checked++;
+}
+
+GST_START_TEST (test_internal_links_during_clear_ssrc_pad_removed)
+{
+  GstHarness *h;
+  PadRemovedInternalLinksCtx ctx = { 0, };
+
+  h = gst_harness_new_with_padnames ("rtpssrcdemux", "sink", NULL);
+
+  gst_harness_set_src_caps (h, generate_caps ());
+
+  fail_unless_equals_int (GST_FLOW_OK,
+      gst_harness_push (h, create_buffer (0, TEST_BUF_SSRC)));
+
+  g_signal_connect (h->element, "pad-removed",
+      G_CALLBACK (pad_removed_iterate_internal_links_cb), &ctx);
+
+  g_signal_emit_by_name (h->element, "clear-ssrc", TEST_BUF_SSRC, NULL);
+
+  fail_unless_equals_int (ctx.n_src_pads_checked, 2);
+
+  gst_harness_teardown (h);
+}
+
+GST_END_TEST;
+
 static Suite *
 rtpssrcdemux_suite (void)
 {
@@ -1012,6 +1088,7 @@ rtpssrcdemux_suite (void)
   tcase_add_test (tc_chain, test_rtcp_chain_list_with_invalid_buffer);
   tcase_add_test (tc_chain, test_rtp_chain_list_max_streams);
   tcase_add_test (tc_chain, test_rtp_chain_list_empty);
+  tcase_add_test (tc_chain, test_internal_links_during_clear_ssrc_pad_removed);
 
   return s;
 }


### PR DESCRIPTION
clear-ssrc removed the SSRC pad bookkeeping before removing the pads from the element. gst_element_remove_pad() can synchronously unlink pads and trigger event/internal-link traversal while the old pads are still alive and/or still parented. In that window, iterate_internal_links_src() must still be able to find the corresponding SSRC pad state.

Keep the GstRtpSsrcDemuxPads entry in demux->srcpads until after both RTP and RTCP pads have been removed from the element, then remove and free the bookkeeping.

The regression is covered by the rtpbin timeout/readd test rather than a direct rtpssrcdemux unit test. The crash depends on the real integration path: autoremove tears down an old stream while the same SSRC reappears, and rtpbin ghost-pad setup forwards sticky events through the still-live old demux pad. A standalone rtpssrcdemux test would need to reproduce that specific synchronous traversal window and would otherwise be either too late or timing-dependent.