### PR TITLE
TWCC: add rtptimestamp into logs to make video frames traversing easier

### DIFF
--- a/subprojects/gst-plugins-good/gst/rtpmanager/rtptwcc.c
+++ b/subprojects/gst-plugins-good/gst/rtpmanager/rtptwcc.c
@@ -975,9 +975,9 @@ rtp_twcc_manager_recv_packet (RTPTWCCManager * twcc, RTPPacketInfo * pinfo)
   if (reordered_packet)
     g_array_sort (twcc->recv_packets, _twcc_seqnum_sort);
 
-  GST_LOG ("Receive: twcc-seqnum: #%u, pt: %u, marker: %d, ts: %"
-      GST_TIME_FORMAT, seqnum, pinfo->pt, pinfo->marker,
-      GST_TIME_ARGS (packet.ts));
+  GST_LOG ("Receive: twcc-seqnum: #%u, seqnum: %u, rtptime: %u, pt: %u, "
+      "marker: %d, ts: %" GST_TIME_FORMAT, seqnum, pinfo->seqnum,
+      pinfo->rtptime, pinfo->pt, pinfo->marker, GST_TIME_ARGS (packet.ts));
 
   if (!pinfo->marker)
     twcc->packet_count_no_marker++;

--- a/subprojects/gst-plugins-good/gst/rtpmanager/rtptwccstats.c
+++ b/subprojects/gst-plugins-good/gst/rtpmanager/rtptwccstats.c
@@ -1543,14 +1543,17 @@ rtp_twcc_stats_sent_pkt (TWCCStatsManager * statsman,
 
   GST_DEBUG_OBJECT
       (statsman->parent,
-      "Send: twcc-seqnum: %u, seqnum: %u, pt: %u, marker: %d, "
+      "Send: twcc-seqnum: %u, seqnum: %u, rtptime: %u, pt: %u, marker: %d, "
       "redundant_idx: %d, redundant_num: %d, protected_seqnums(rtp): %u, "
       "protected_seqnums(twcc): %u, "
-      "size: %u, ts: %" GST_TIME_FORMAT, packet.seqnum, pinfo->seqnum,
-      packet.pt, pinfo->marker, packet.redundant_idx, packet.redundant_num,
+      "size: %u, ts: %" GST_TIME_FORMAT ", pts: %" GST_TIME_FORMAT,
+      packet.seqnum, pinfo->seqnum,
+      packet.timestamp, packet.pt, pinfo->marker, packet.redundant_idx,
+      packet.redundant_num,
       packet.protects_seqnums ? packet.protects_seqnums->len : 0,
       packet.protects_twcc_seqnums ? packet.protects_twcc_seqnums->len : 0,
-      packet.size, GST_TIME_ARGS (pinfo->current_time));
+      packet.size, GST_TIME_ARGS (pinfo->current_time),
+      GST_TIME_ARGS (pinfo->running_time));
 }
 
 void


### PR DESCRIPTION
Extra logging to make tracing frames and packets among different nodes easier.